### PR TITLE
Add project specific color vars to _presets.scss

### DIFF
--- a/_sass/colors/_presets.scss
+++ b/_sass/colors/_presets.scss
@@ -11,3 +11,5 @@ $strong-blue: #28318c;
 $light-red: #ff625f;
 $white: #ffffff;
 $light-blue: #8291e8;
+$dark-blue: #00187c;
+$dark-red: #db3934;

--- a/_sass/colors/_presets.scss
+++ b/_sass/colors/_presets.scss
@@ -5,3 +5,9 @@
 
 //Current Preset Declareation
  $preset:  $blue;
+
+// Project Specific Colors
+$strong-blue: #28318c;
+$light-red: #ff625f;
+$white: #ffffff;
+$light-blue: #8291e8;


### PR DESCRIPTION
The following color vars have been added to the preset file:

$strong-blue
$light-red
$white
$light-blue
$dark-blue
$dark-red